### PR TITLE
WIP - migrating to new API + cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.14)
+project(yavl)
+
+set(CMAKE_CXX_STANDARD 14)
+
+add_subdirectory(src)
+add_subdirectory(example-code)

--- a/example-code/CMakeLists.txt
+++ b/example-code/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(example-code checker.cpp)
+
+target_compile_options(example-code PUBLIC -Werror -Wall -O3 -Wextra -pedantic -Wold-style-cast
+        -Wdouble-promotion -Wuninitialized -Wshadow -Wuseless-cast)
+
+target_link_libraries(example-code PUBLIC yavl_cpp)

--- a/example-code/checker.cpp
+++ b/example-code/checker.cpp
@@ -1,22 +1,22 @@
 #include <fstream>
 #include <iostream>
-#include "yaml.h"
+#include "yaml-cpp/yaml.h"
 #include "yavl.h"
 
 using namespace std;
 
 int main(int argc, char **argv)
 {
-  std::ifstream grin; // grammar file
-  grin.open(argv[1]);
-  
-  std::ifstream yin; // file to be checked
-  yin.open(argv[2]);
-  
+  if(argc != 3) {
+    std::cerr << "should have 2 arguments grammer file(schema) and file to be checked (argc = " << argc << " )\n";
+    return -1;
+  }
+  // argv[1] grammar file
+  // argv[2] file to be checked
+
   YAML::Node gr;
   try {
-    YAML::Parser parser(grin);
-    parser.GetNextDocument(gr);
+    gr = YAML::LoadFile(argv[2]);
   } catch(const YAML::Exception& e) {
     std::cerr << "Error reading grammar: " << e.what() << "\n";
     return 1;
@@ -24,8 +24,7 @@ int main(int argc, char **argv)
 
   YAML::Node doc;
   try {
-    YAML::Parser parser(yin);
-    parser.GetNextDocument(doc);
+    doc = YAML::LoadFile(argv[1]);
   } catch(const YAML::Exception& e) {
     std::cerr << "Error reading document: " << e.what() << "\n";
     return 2;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(yavl_cpp
+        yavl.cpp
+        yavl.h)
+
+target_compile_options(yavl_cpp PUBLIC -Werror -Wall -O3 -Wextra -pedantic -Wold-style-cast
+        -Wdouble-promotion -Wuninitialized -Wshadow -Wuseless-cast)
+
+target_include_directories(yavl_cpp PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(yavl_cpp PUBLIC yaml-cpp)

--- a/src/yavl.h
+++ b/src/yavl.h
@@ -1,10 +1,14 @@
+// FIXME we need license/copyright here
+
 #ifndef _YAVL_H_
 #define _YAVL_H_
 
-#include "yaml.h"
 #include <vector>
 #include <string>
 #include <ostream>
+
+#include "yaml-cpp/yaml.h"
+#include "yaml-cpp/node/node.h"
 
 namespace YAVL
 {
@@ -33,18 +37,18 @@ namespace YAVL
   typedef std::vector<Exception> Errors;
 
   class Validator {
-    const YAML::Node& gr;
+    const YAML::Node& _gr;
     const YAML::Node& doc;
     Path gr_path;
     Path doc_path;
     Errors errors;
 
-    int num_keys(const YAML::Node& doc);
-    const std::string& type2str(YAML::CONTENT_TYPE t);
-    bool validate_map(const YAML::Node &mapNode, const YAML::Node &doc);
-    bool validate_leaf(const YAML::Node &gr, const YAML::Node &doc);
-    bool validate_list(const YAML::Node &gr, const YAML::Node &doc);
-    bool validate_doc(const YAML::Node &gr, const YAML::Node &doc);
+    int num_keys(const YAML::Node& document);
+    const std::string& type2str(YAML::NodeType::value t);
+    bool validate_map(const YAML::Node &mapNode, const YAML::Node &document);
+    bool validate_leaf(const YAML::Node &gr, const YAML::Node &document);
+    bool validate_list(const YAML::Node &gr, const YAML::Node &document);
+    bool validate_doc(const YAML::Node &gr, const YAML::Node &document);
 
     void gen_error(const Exception& err) {
       errors.push_back(err);
@@ -53,11 +57,10 @@ namespace YAVL
     template<typename T>
     void attempt_to_convert(const YAML::Node& scalar_node, bool& ok) {
       try {
-        T tmp;
-        scalar_node >> tmp;
+        (void) scalar_node.as<T>();
         ok = true;
       } catch (const YAML::InvalidScalar& e) {
-        std::string s = scalar_node;
+        std::string s = scalar_node.as<std::string>();
         std::string reason = "unable to convert '" + s + "' to '" + YAVL::ctype2str<T>() + "'.";
         gen_error(Exception(reason, gr_path, doc_path));
         ok = false;
@@ -65,10 +68,10 @@ namespace YAVL
     }
 
   public:
-    Validator(const YAML::Node& _gr, const YAML::Node& _doc) :
-      gr(_gr), doc(_doc) {};
+    Validator(const YAML::Node& gr, const YAML::Node& _doc) :
+      _gr(gr), doc(_doc) {};
     bool validate() {
-      return validate_doc(gr, doc);
+      return validate_doc(_gr, doc);
     }
     const Errors& get_errors() {
       return errors;


### PR DESCRIPTION
migrating to new API, on ubuntu 16.04 + cmake support

Still WIP. the example asserts with:
(from the build dir:)
example-code/example-code ../example-specs/gr3.yaml ../example-specs/y0.gr3.yaml
example-code: /home/kobic/develop/yavl-cpp/src/yavl.cpp:140: bool YAVL::Validator::validate_leaf(const YAML::Node&, const YAML::Node&): Assertion `gr.Type() == YAML::NodeType::Sequence' failed.
Aborted (core dumped)

did not debug it yet. maybe you can have a clue about what's going on while I'm looking at it.

to build it:
```
mkdir  build
cd build
cmake -DCMAKE_BUILD_TYPE=Debug ..
make
```